### PR TITLE
fix: improve SEO and sitemap issues

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+sitemap: false
 ---
 
 <style type="text/css" media="screen">

--- a/_config.yml
+++ b/_config.yml
@@ -61,6 +61,7 @@ defaults:
       type: tags
     values:
       layout: tag
+      sitemap: false
 
 exclude: [README.md, Gemfile, Gemfile.lock]
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -23,6 +23,12 @@
 {% unless meta_image contains '://' %}
 {% assign meta_image = meta_image | prepend: site.url %}
 {% endunless %}
+<link rel="canonical" href="{{ meta_url }}" />
+{% if paginator and paginator.page > 1 %}
+<meta name="robots" content="noindex, follow" />
+{% elsif page.noindex %}
+<meta name="robots" content="noindex, follow" />
+{% endif %}
 <title>{{ meta_title }}</title>
 <meta name="title" content="{{ meta_title }}" />
 <meta name="author" content="{{ meta_author }}"/>
@@ -35,7 +41,7 @@
 <meta property="og:title" content="{{ meta_title }}"/>
 <meta property="og:description" content="{{ meta_description }}"/>
 <meta property="og:url" content="{{ meta_url }}"/>
-<meta property="og:image" content="{{ page.image }}"/>
+<meta property="og:image" content="{{ meta_image }}"/>
 <meta name="twitter:card" content="summary_large_image"/>
 <meta name="twitter:title" content="{{ meta_title }}"/>
 <meta name="twitter:description" content="{{ meta_description }}"/>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,6 +1,19 @@
 ---
 layout: default
 ---
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": {{ site.title | jsonify }},
+  "url": "{{ site.url }}",
+  "description": {{ site.description | strip_html | strip_newlines | jsonify }},
+  "author": {
+    "@type": "Person",
+    "name": {{ site.author | jsonify }}
+  }
+}
+</script>
 <div id="cover" class="container"
     {% if site.image %}style="background-image:url({{ site.image }});"{% endif %}>
     <div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,6 +1,40 @@
 ---
 layout: default
 ---
+{% assign author = site.authors | where: 'name', page.author | first %}
+{% assign post_image = page.image | default: site.image %}
+{% unless post_image contains '://' %}{% assign post_image = post_image | prepend: site.url %}{% endunless %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": {{ page.title | jsonify }},
+  "description": {{ page.excerpt | strip_html | truncatewords: 75 | jsonify }},
+  "image": {{ post_image | jsonify }},
+  "datePublished": "{{ page.date | date_to_xmlschema }}",
+  {% if page.modified %}"dateModified": "{{ page.modified }}",{% endif %}
+  "author": {
+    "@type": "Person",
+    "name": {{ page.author | default: site.author | jsonify }},
+    "url": "{{ site.url }}{{ author.url }}"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": {{ site.title | jsonify }},
+    "logo": {
+      "@type": "ImageObject",
+      "url": "{{ site.url }}/assets/favicon.png"
+    }
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "{{ site.url }}{{ page.url }}"
+  }
+  {% if page.tags %},
+  "keywords": {{ page.tags | jsonify }}
+  {% endif %}
+}
+</script>
 <div id="fb-root"></div>
 <div id="navbar" class="container">
     <h5><a id="link-back" href="/">Back to Posts</a></h5>

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+noindex: true
 ---
 <div id="navbar" class="container">
     <h5><a id="link-back" href="/">Main</a></h5>

--- a/_posts/2020-11-17-configuration-dhcp.md
+++ b/_posts/2020-11-17-configuration-dhcp.md
@@ -5,7 +5,7 @@ description: " "
 author: chhanz
 date: 2020-11-17
 tags: [linux]
-category: linux, dhcp
+categories: [linux, dhcp]
 ---
    
 # DHCP 란?

--- a/robots.txt
+++ b/robots.txt
@@ -1,5 +1,5 @@
 User-agent: *
 Allow: /
-Disallow: /assets/
+Disallow: /assets/images/
 
 Sitemap: https://tech.chhanz.xyz/sitemap.xml


### PR DESCRIPTION
## Summary
- Add `<link rel="canonical">` tag to resolve Google Search Console sitemap detection failure
- Change `robots.txt` to block only `/assets/images/` instead of entire `/assets/` (allow CSS/JS crawling for Googlebot rendering)
- Exclude 404 page and tag pages from sitemap, add `noindex` meta tag for pagination/tag pages
- Fix DHCP post malformed URL (`category: linux, dhcp` → `categories: [linux, dhcp]`)
- Fix `og:image` fallback bug (`page.image` → `meta_image`)
- Add `BlogPosting` / `WebSite` JSON-LD structured data for rich search results

## Changed files
| File | Change |
|------|--------|
| `_includes/head.html` | canonical URL, noindex for pagination/tag, og:image fix |
| `robots.txt` | `/assets/` → `/assets/images/` |
| `404.html` | `sitemap: false` |
| `_config.yml` | tag collection `sitemap: false` |
| `_layouts/tag.html` | `noindex: true` |
| `_layouts/post.html` | BlogPosting JSON-LD |
| `_layouts/home.html` | WebSite JSON-LD |
| `_posts/2020-11-17-configuration-dhcp.md` | category fix |

