### PR TITLE
improve: change font from Noto Sans KR to Pretendard

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -72,7 +72,7 @@
 <link href="{{ site.asset_url }}/css/syntax-stackoverflow-dark.css" rel="stylesheet" type="text/css"/>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="//fonts.googleapis.com/earlyaccess/notosanskr.css" rel="stylesheet" type="text/css" media="print" onload="this.media='all'"/>
+<link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css" rel="stylesheet" type="text/css"/>
 <link href="{{ site.asset_url }}/lib/magnific-popup.min.css" rel="stylesheet" type="text/css"/>
 <link href="{{ site.asset_url }}/css/screen.css" rel="stylesheet" type="text/css"/>
 <link href="{{ site.asset_url }}/css/dark-mode.css" rel="stylesheet" type="text/css"/>

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -9,7 +9,7 @@
 }
 
 body {
-    font-family: 'Noto Sans KR', 'NanumBarunGothic', sans-serif;
+    font-family: 'Pretendard Variable', 'Pretendard', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
     font-weight: 300; /* @@iolo 200 -> 300, 200 for retina only! */
     color: #505050;
     background-color: #fff;
@@ -28,7 +28,7 @@ h3,
 h4,
 h5,
 h6 {
-    font-family: 'Noto Sans KR', 'NanumBarunGothic', sans-serif;
+    font-family: 'Pretendard Variable', 'Pretendard', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
     font-weight: 400;
     color: #1e1e1e;
 }
@@ -37,7 +37,7 @@ pre,
 code,
 tt,
 kbd {
-    font-family: Consolas, Monaco, 'Liberation Mono', 'Noto Sans KR', 'NanumBarunGothic', monospace;
+    font-family: Consolas, Monaco, 'Liberation Mono', 'Pretendard Variable', 'Pretendard', monospace;
     font-weight: 300;
 }
 
@@ -572,7 +572,7 @@ for small screen(<720px):
 #cover,
 #navbar,
 #footer {
-    font-family: 'Noto Sans KR', 'NanumBarunGothic', sans-serif;
+    font-family: 'Pretendard Variable', 'Pretendard', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
 }
 
 /* list(loop) */
@@ -917,7 +917,7 @@ body.tag-template #navbar {
     padding: 28px;
     border-left: 3px solid #e5e5e5;
     font-style: italic;
-    font-family: 'Noto Sans KR', 'NanumBarunGothic', sans-serif;
+    font-family: 'Pretendard Variable', 'Pretendard', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
 }
 
 #post-content blockquote > *:first-child {


### PR DESCRIPTION
## Summary
- Replace Noto Sans KR + NanumBarunGothic with Pretendard Variable
- Load via jsDelivr CDN (dynamic subset for optimal performance)
- Fallback chain: -apple-system, BlinkMacSystemFont, system-ui, sans-serif
- Font-only swap, no layout or design changes

## Changed files
| File | Change |
|------|--------|
| `_includes/head.html` | CDN URL: Google Fonts earlyaccess → jsDelivr Pretendard |
| `assets/css/screen.css` | `font-family` 5곳 교체 (body, headings, code, header/footer, blockquote) |

## Test plan
- [ ] Jekyll 빌드 성공 확인 (GitHub Actions)
- [ ] 메인 페이지에서 Pretendard 폰트 로딩 확인 (DevTools > Network > Font)
- [ ] 한글/영문 가독성 확인
- [ ] 다크모드에서 폰트 렌더링 정상 확인
- [ ] 모바일에서 폰트 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)